### PR TITLE
 keep compatibility when no parallel

### DIFF
--- a/functions/infer_pruned.py
+++ b/functions/infer_pruned.py
@@ -210,7 +210,7 @@ def accuracy(output, target, topk=(1,)):
 def remove_module_dict(state_dict):
     new_state_dict = OrderedDict()
     for k, v in state_dict.items():
-        name = k[7:]  # remove `module.`
+        name = name.replace("module.", "")  # remove `module.`
         new_state_dict[name] = v
     return new_state_dict
 

--- a/functions/infer_pruned.py
+++ b/functions/infer_pruned.py
@@ -210,7 +210,7 @@ def accuracy(output, target, topk=(1,)):
 def remove_module_dict(state_dict):
     new_state_dict = OrderedDict()
     for k, v in state_dict.items():
-        name = name.replace("module.", "")  # remove `module.`
+        name = name[7:] if name.startswith("module.") else name  # remove `module.`
         new_state_dict[name] = v
     return new_state_dict
 


### PR DESCRIPTION
If there is no parallel when saving model state dict, there is no "module." prefix in the state dict keys.